### PR TITLE
忘记密码界面点击获取邮件验证码按钮，浏览器console显示Uncaught ReferenceError: sendEmailCodeF…

### DIFF
--- a/src/main/resources/templates/site/reset-pwd.html
+++ b/src/main/resources/templates/site/reset-pwd.html
@@ -101,6 +101,6 @@
 	<script th:src="@{/js/jquery-3.1.0.min.js}"></script>
 	<script th:src="@{/js/popper.min.js}"></script>
 	<script th:src="@{/js/bootstrap.min.js}"></script>
-	<script th:src="@{/static/js/reset-pwd.js}"></script>
+	<script th:src="@{/js/reset-pwd.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
忘记密码界面点击获取邮件验证码按钮，浏览器console显示Uncaught ReferenceError: sendEmailCodeForResetPwd is not defined，推测应该是/static/js/reset-pwd.js路径错误，修改为/js/reset-pwd.js后功能正常。